### PR TITLE
fix Slovak translations

### DIFF
--- a/utilities/microservice/src/main/java/translationapi/Microservice.java
+++ b/utilities/microservice/src/main/java/translationapi/Microservice.java
@@ -127,7 +127,7 @@ public class Microservice {
     Map<String, String> slovakTranslations = new HashMap<>();
     slovakTranslations.put("hello", "ahoj");
     slovakTranslations.put("goodbye", "zbohom");
-    slovakTranslations.put("thanks", "ďakujem koe");
+    slovakTranslations.put("thanks", "ďakujem);
     translations.put("sk", slovakTranslations);
 
     // Turkish translations


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I corrected the translation for "thanks" in Slovak in all exercises.

## Why?
<!-- Tell your future self why have you made these changes -->

As per https://github.com/temporalio/edu-102-typescript-code/pull/54, the existing translation was incorrect. The inclusion of "koe" was a copy-paste error from the Maori translation that preceded the Slovak one. 
